### PR TITLE
Fix implementation of org.slf4j.spi.SLF4JServiceProvider

### DIFF
--- a/src/datalogger/impl/provider.clj
+++ b/src/datalogger/impl/provider.clj
@@ -21,7 +21,7 @@
 (defn -getMDCAdapter [^SLF4JServiceProvider this]
   (force mdc-adapter))
 
-(defn -getRequesteApiVersion [^SLF4JServiceProvider this]
+(defn -getRequestedApiVersion [^SLF4JServiceProvider this]
   NOP_FallbackServiceProvider/REQUESTED_API_VERSION)
 
 (defn -initialize [^SLF4JServiceProvider this]

--- a/test/datalogger/impl/provider_test.clj
+++ b/test/datalogger/impl/provider_test.clj
@@ -1,0 +1,6 @@
+(ns datalogger.impl.provider-test
+  (:require [clojure.test :refer :all])
+  (:import [datalogger.impl provider]))
+
+(deftest getRequestedApiVersion-test
+  (is (string? (.getRequestedApiVersion (new provider)))))


### PR DESCRIPTION
This typo causes exceptions on a fresh project that only imports this library.

```
java.lang.UnsupportedOperationException: getRequestedApiVersion (datalogger.impl.provider/-getRequestedApiVersion not defined?)
at datalogger.impl.provider.getRequestedApiVersion (:-1)
datalogger.impl.provider_test$fn__1717.invokeStatic (provider_test.clj:6)
datalogger.impl.provider_test/fn (provider_test.clj:5)
clojure.test$test_var$fn__9761.invoke (test.clj:717)
clojure.test$test_var.invokeStatic (test.clj:717)
clojure.test$test_var.invoke (test.clj:708)
clojure.test$test_vars$fn__9787$fn__9792.invoke (test.clj:735)
clojure.test$default_fixture.invokeStatic (test.clj:687)
clojure.test$default_fixture.invoke (test.clj:683)
clojure.test$test_vars$fn__9787.invoke (test.clj:735)
```