### PR TITLE
Log an exception's class.

### DIFF
--- a/src/datalogger/protos.clj
+++ b/src/datalogger/protos.clj
@@ -48,9 +48,13 @@
     (as-data
       (if (:root-only options)
         (let [root ^Throwable (stack/root-cause x)]
-          (cond-> {:message (ex-message root) :trace (vec (.getStackTrace root))}
+          (cond-> {:class (.getName (class root))
+                   :message (ex-message root)
+                   :trace (vec (.getStackTrace root))}
             (ex-data root) (assoc :data (ex-data root))))
-        (cond-> {:message (ex-message x) :trace (vec (.getStackTrace x))}
+        (cond-> {:class (.getName (class x))
+                 :message (ex-message x)
+                 :trace (vec (.getStackTrace x))}
           (ex-data x) (assoc :data (ex-data x))
           (.getCause x) (assoc :cause (.getCause x))))
       options))

--- a/test/datalogger/core_test.clj
+++ b/test/datalogger/core_test.clj
@@ -32,11 +32,17 @@
   (let [trace-pattern (repeat {"class" string? "filename" string? "line" number? "method" string?})]
     (testing "tree of exceptions"
       (with-config {:exceptions {:root-only false}}
-        (assert-logs [{"exception" {"message" "Outer" "trace" trace-pattern "cause" {"message" "Inner"}}}]
+        (assert-logs [{"exception" {"class" "java.lang.RuntimeException"
+                                    "message" "Outer"
+                                    "trace" trace-pattern
+                                    "cause" {"message" "Inner"}}}]
           (log :error (RuntimeException. "Outer" (ex-info "Inner" {}))))))
     (testing "only the root exception"
       (with-config {:exceptions {:root-only true}}
-        (assert-logs [{"exception" {"message" "Inner" "trace" trace-pattern "cause" nil?}}]
+        (assert-logs [{"exception" {"class" "clojure.lang.ExceptionInfo"
+                                    "message" "Inner"
+                                    "trace" trace-pattern
+                                    "cause" nil?}}]
           (log :error (RuntimeException. "Outer" (ex-info "Inner" {}))))))))
 
 (deftest clojure-logging-with-context


### PR DESCRIPTION
Previously, a logged exception didn't include the exception's class:

    datalogger.core=> (log :error (IllegalStateException. "entered a bad state"))
    {
      "@hostname": "Mac",
      "@thread": "main",
      "@timestamp": "2024-11-27T15:00:17.090666Z",
      "column": 1,
      "exception": {
        "message": "entered a bad state",
        "trace": [...]
      },
      "level": "ERROR",
      "line": 1,
      "logger": "datalogger.core",
      "ns": "datalogger.core"
    }

Add a "class" key to the logged exception.