### PR TITLE
Construct slf4j Loggers that also implement LoggingEventAware.

### DIFF
--- a/src/datalogger/impl/loggers.clj
+++ b/src/datalogger/impl/loggers.clj
@@ -5,9 +5,12 @@
             [datalogger.impl.context :as context]
             [datalogger.impl.utils :as utils])
   (:import (org.slf4j ILoggerFactory Marker)
+           (org.slf4j.event KeyValuePair LoggingEvent)
            (org.slf4j.helpers LegacyAbstractLogger MessageFormatter)
+           (org.slf4j.spi LoggingEventAware)
            (java.util.function Supplier)
            (clojure.lang Agent ISeq IFn)
+           (java.time Instant)
            (java.util.concurrent Executor)))
 
 (set! *warn-on-reflection* true)
@@ -27,9 +30,10 @@
     msg))
 
 (defn data-logger [logger-name]
-  (proxy [LegacyAbstractLogger] []
+  (proxy [LegacyAbstractLogger LoggingEventAware] []
     (getName []
       logger-name)
+    ;; org.slf4j.helpers.LegacyAbstractLogger
     (isTraceEnabled
       ([] ((config/get-log-filter) logger-name :trace))
       ([^Marker marker] ((config/get-log-filter) logger-name :trace)))
@@ -45,6 +49,7 @@
     (isErrorEnabled
       ([] ((config/get-log-filter) logger-name :error))
       ([^Marker marker] ((config/get-log-filter) logger-name :error)))
+    ;; org.slf4j.helpers.AbstractLogger
     (getFullyQualifiedCallerName [] nil)
     (handleNormalizedLoggingCall [level marker message arguments throwable]
       (let [current-context  (context/get-context-for-level (str level))
@@ -67,6 +72,53 @@
                                          callsite-context
                                          extras
                                          {:message (maybe-format message arguments)})))
+                   ^ISeq
+                   (seq [])
+                   ^Executor
+                   Agent/soloExecutor)))
+    ;; org.slf4j.spi.LoggingEventAware
+    (log [^LoggingEvent event]
+      (let [level            (str (.getLevel event))
+            current-context  (context/get-context-for-level level)
+            current-mdc      (context/get-mdc)
+            current-extra    (merge (context/execution-context)
+                                    (when-let [thread (.getThreadName event)]
+                                      {"@thread" thread})
+                                    (let [timestamp (.getTimeStamp event)]
+                                      ;; `LoggingEvent`'s timestamp is a primitive, so it cannot be null. Check for its
+                                      ;; default value. This does preclude the possibility of logging events that happen
+                                      ;; at the moment of the epoch. Given that it has been a few years since the epoch,
+                                      ;; that is hopefully not necessary.
+                                      (when-not (zero? timestamp)
+                                        ;; <https://www.slf4j.org/apidocs/org/slf4j/event/LoggingEvent.html#getTimeStamp()>
+                                        ;; does not describe the format of this timestamp, but usage
+                                        ;; (e.g. <https://github.com/qos-ch/slf4j/blob/v_2.0.16/slf4j-jdk14/src/main/java/org/slf4j/jul/JDK14LoggerAdapter.java#L290>)
+                                        ;; implies that is epoch milliseconds.
+                                        {"@timestamp" (Instant/ofEpochMilli timestamp)})))
+            callsite-context (callsite-info)
+            extras           (merge {:level  level
+                                     :logger (.getLoggerName event)}
+                                    (when-let [throwable (.getThrowable event)]
+                                      {:exception throwable}))
+            config           (deref config/*config*)
+            out              (config/get-log-stream (:stream config))]
+        ;; NOTE `event`'s markers are ignored. According to <https://www.slf4j.org/apidocs/org/slf4j/Marker.html>, that
+        ;; is acceptable: "Many conforming logging systems ignore marker data entirely."
+        (.dispatch ^Agent context/logging-agent
+                   ^IFn
+                   (fn [_]
+                     (context/write! config out
+                       (utils/deep-merge current-extra
+                                         current-mdc
+                                         current-context
+                                         callsite-context
+                                         extras
+                                         (into {}
+                                               (map (fn [^KeyValuePair kvp] [(.-key kvp) (.-value kvp)]))
+                                               (.getKeyValuePairs event))
+                                         {:message (-> event
+                                                       .getMessage
+                                                       (maybe-format (.getArguments event)))})))
                    ^ISeq
                    (seq [])
                    ^Executor

--- a/test/datalogger/core_test.clj
+++ b/test/datalogger/core_test.clj
@@ -53,7 +53,20 @@
 
 (deftest slf4j-logging
   (assert-logs [{"level" "ERROR" "message" "Demonstration 1."}]
-    (.error slf4j-logger "Demonstration {}." 1)))
+    (.error slf4j-logger "Demonstration {}." 1))
+  (testing "slf4j events are logged richly"
+    (let [e (Exception.)]
+      (assert-logs [{"level" "ERROR"
+                     "message" "Demonstration 1."
+                     "exception" {"class" "java.lang.Exception"}
+                     "foo" {"bar" "baz"}}]
+        (-> slf4j-logger
+            .atError
+            (.setCause e)
+            (.setMessage "Demonstration {}.")
+            ^org.slf4j.spi.LoggingEventBuilder (.addArgument 1)
+            (.addKeyValue "foo" ^Object {:bar "baz"})
+            .log)))))
 
 (deftest slf4j-logging-mdc
   (assert-logs [{"key" "value"}]


### PR DESCRIPTION
When Java (or Clojure) code uses a LoggingEventBuilder like

    logger.atDebug().setMessage("Temperature changed.").addKeyValue("oldT", oldT).addKeyValue("newT", newT).log();

Then the default implementation will do this:
<https://github.com/qos-ch/slf4j/blob/v_2.0.16/slf4j-api/src/main/java/org/slf4j/spi/DefaultLoggingEventBuilder.java#L163>. So if the Logger implements org.slf4j.spi.LoggingEventAware, it gets to handle the LoggingEvent's key-value pairs in a first-class manner. But if it doesn't, that data is just shoved into the message. It's preferable to get key-value pairs and log them as a JSON map, so construct Logger objects that implement LoggingEventAware and do that.